### PR TITLE
Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -25,3 +25,7 @@ jobs:
           packagePublishRepo: ${{ github.repository }}
         run: |
           ./gradlew clean build publish --stacktrace --scan --console=plain --no-daemon
+          ./gradlew codeCoverageReport
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
+

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,11 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
+        run: |
+          ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
+          ./gradlew codeCoverageReport
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
 
   windows-build:
     runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build](https://github.com/ballerina-platform/module-ballerinax-prometheus/workflows/Daily%20Build/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-prometheus/actions?query=workflow%3A"Daily+Build")
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-prometheus.svg)](https://github.com/ballerina-platform/module-ballerinax-prometheus/commits/main)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![codecov](https://codecov.io/gh/ballerina-platform/module-ballerinax-prometheus/branch/main/graph/badge.svg)](https://codecov.io/gh/ballerina-platform/module-ballerina-prometheus)
+[![codecov](https://codecov.io/gh/ballerina-platform/module-ballerinax-prometheus/branch/main/graph/badge.svg)](https://codecov.io/gh/ballerina-platform/module-ballerinax-prometheus)
 
 The Prometheus Observability Extension is one of the metrics extensions of the <a target="_blank" href="https://ballerina.io/">Ballerina</a> language.
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id "com.github.spotbugs" version "4.5.1"
     id "net.researchgate.release" version "2.8.0"
     id "de.undercouch.download" version "4.0.4"
+    id 'jacoco'
 }
 
 allprojects {
@@ -271,6 +272,28 @@ release {
     }
 }
 
+task codeCoverageReport(type: JacocoReport) {
+    dependsOn('prometheus-extension-ballerina:extractBallerinaClassFiles')
+
+    executionData fileTree(project.rootDir.absolutePath).include("**/*.exec")
+
+    additionalClassDirs files("${buildDir}/classes")
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+        csv.enabled = true
+        xml.destination = new File("${buildDir}/reports/jacoco/report.xml")
+        html.destination = new File("${buildDir}/reports/jacoco/report.html")
+        csv.destination = new File("${buildDir}/reports/jacoco/report.csv")
+    }
+
+    onlyIf = {
+        true
+    }
+}
+
 task build {
     dependsOn('prometheus-extension-ballerina:build')
 }
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+fixes:
+  - "ballerinax/prometheus/*/::prometheus-extension-ballerina/"
+
+ignore:
+  - "**/prometheus-extension-tests"
+

--- a/prometheus-extension-ballerina/build.gradle
+++ b/prometheus-extension-ballerina/build.gradle
@@ -94,6 +94,7 @@ def tomlVersion = project.version.split("-")[0]
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def originalConfig = ballerinaConfigFile.text
 def originalDependencyConfig = ballerinaDependencyFile.text
+def artifactJars = file("$project.projectDir/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
 
 task updateTomlVerions {
     doLast {
@@ -222,3 +223,14 @@ publishing {
 build {
     dependsOn ballerinaBuild
 }
+
+task extractBallerinaClassFiles(type: Copy) {
+    fileTree(artifactJars).forEach { file ->
+        from zipTree(file).matching {
+            exclude '**/tests/*'
+            include '**/*.class'
+        }
+        into "${project.rootDir.absolutePath}/build/classes"
+    }
+}
+


### PR DESCRIPTION
## Purpose
- Introducing `Codecov` code coverage report publishing to the `prometheus` repository

## Goals
- Publishing the testerina generated code coverage xml to `Codecov` triggered via GitHub action of PR.

## Approach
- A new job is inserted to `Pull request` GitHub actions that publishes the XML report to  `Codecov`.
- These jobs trigger on merge to master or pull request and `CodeCov` generates a descriptive code coverage report.
- `Codecov` also adds comments to any PR made based on the code coverage changes between commits

## Test environment
- Ubuntu 20.04
