### PR TITLE
Add support to automatically push the releases to Ballerina Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,40 +5,6 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![codecov](https://codecov.io/gh/ballerina-platform/module-ballerinax-prometheus/branch/main/graph/badge.svg)](https://codecov.io/gh/ballerina-platform/module-ballerinax-prometheus)
 
-The Prometheus Observability Extension is one of the metrics extensions of the <a target="_blank" href="https://ballerina.io/">Ballerina</a> language.
-
-It provides an implementation for exporting metrics to a Prometheus Server.
-
-## Enabling Prometheus Extension
-
-To package the Prometheus extension into the Jar, follow the following steps.
-1. Add the following import to your program.
-```ballerina
-import ballerinax/prometheus as _;
-```
-
-2. Add the following to the `Ballerina.toml` when building your program.
-```toml
-[package]
-org = "my_org"
-name = "my_package"
-version = "1.0.0"
-
-[build-options]
-observabilityIncluded=true
-```
-
-To enable the extension and export metrics to Prometheus, add the following to the `Config.toml` when running your program.
-```toml
-[ballerina.observe]
-metricsEnabled=true
-metricsReporter="prometheus"
-
-[ballerinax.prometheus]
-host="127.0.0.1"  # Optional Configuration. Default value is localhost
-port=9797         # Optional Configuration. Default value is 9797
-```
-
 ## Building from the Source
 
 ### Setting Up the Prerequisites

--- a/build.gradle
+++ b/build.gradle
@@ -236,13 +236,11 @@ subprojects {
     }
 }
 
-def moduleVersion = project.version
-if (moduleVersion.indexOf('-') != -1) {
-    moduleVersion = moduleVersion.substring(0, moduleVersion.indexOf('-'))
-}
+def moduleVersion = project.version.replace("-SNAPSHOT", "")
 
 release {
     failOnPublishNeeded = false
+    failOnSnapshotDependencies = true
 
     buildTasks = ['build']
     versionPropertyFile = 'gradle.properties'

--- a/prometheus-extension-ballerina/Package.md
+++ b/prometheus-extension-ballerina/Package.md
@@ -1,0 +1,35 @@
+## Package Overview
+
+The Prometheus Observability Extension is one of the metrics extensions of the <a target="_blank" href="https://ballerina.io/">Ballerina</a> language.
+
+It provides an implementation for exporting metrics to a Prometheus Server.
+
+### Enabling Prometheus Extension
+
+To package the Prometheus extension into the Jar, follow the following steps.
+1. Add the following import to your program.
+```ballerina
+import ballerinax/prometheus as _;
+```
+
+2. Add the following to the `Ballerina.toml` when building your program.
+```toml
+[package]
+org = "my_org"
+name = "my_package"
+version = "1.0.0"
+
+[build-options]
+observabilityIncluded=true
+```
+
+To enable the extension and export metrics to Prometheus, add the following to the `Config.toml` when running your program.
+```toml
+[ballerina.observe]
+metricsEnabled=true
+metricsReporter="prometheus"
+
+[ballerinax.prometheus]
+host="127.0.0.1"  # Optional Configuration. Default value is localhost
+port=9797         # Optional Configuration. Default value is 9797
+```

--- a/prometheus-extension-ballerina/build.gradle
+++ b/prometheus-extension-ballerina/build.gradle
@@ -96,6 +96,7 @@ def originalConfig = ballerinaConfigFile.text
 def originalDependencyConfig = ballerinaDependencyFile.text
 def artifactJars = file("$project.projectDir/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
 def platform = "any"
+def distributionBinPath = "${project.buildDir.absolutePath}/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
@@ -145,8 +146,6 @@ task ballerinaBuild {
     finalizedBy(revertTomlFile)
 
     doLast {
-        def distributionBinPath = "${project.buildDir.absolutePath}/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
-
         def additionalBuildParams = ""
         if (project.hasProperty("debug")) {
             additionalBuildParams = "--debug ${project.findProperty("debug")}"
@@ -175,20 +174,6 @@ task ballerinaBuild {
             into file("$artifactCacheParent/cache/")
         }
 
-        // Publish to central
-        if (!project.version.endsWith('-SNAPSHOT') && ballerinaCentralAccessToken != null && project.hasProperty("publishToCentral")) {
-            println("Publishing to the ballerina central..")
-            exec {
-                workingDir project.projectDir
-                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
-                } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
-                }
-            }
-
-        }
         // Doc creation and packing
         exec {
             workingDir project.projectDir
@@ -219,6 +204,34 @@ artifacts {
     distribution createArtifactZip
 }
 
+task ballerinaPublish {
+    dependsOn updateTomlVerions
+    dependsOn ballerinaBuild
+    dependsOn ":${packageName}-extension-tests:test"
+
+    finalizedBy(revertTomlFile)
+
+    doLast {
+        if (project.version.endsWith('-SNAPSHOT')) {
+            return
+        }
+        if (ballerinaCentralAccessToken != null) {
+            println("Publishing to the ballerina central...")
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                }
+            }
+        } else {
+            throw new InvalidUserDataException("Central Access Token is not present")
+        }
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -242,6 +255,10 @@ build {
     dependsOn ballerinaBuild
 }
 
+publish {
+    dependsOn ballerinaPublish
+}
+
 task extractBallerinaClassFiles(type: Copy) {
     fileTree(artifactJars).forEach { file ->
         from zipTree(file).matching {
@@ -251,4 +268,3 @@ task extractBallerinaClassFiles(type: Copy) {
         into "${project.rootDir.absolutePath}/build/classes"
     }
 }
-


### PR DESCRIPTION
## Purpose
> Add support to automatically push the releases to Ballerina Central.

## Goals
> Since, prometheus extension is removed from the Ballerina Distribution, the package need to be pushed to Ballerina Central so that users can use it.

## Approach
> Push the Ballerina packages to Ballerina Central in the Publish Release workflow.