### PR TITLE
Remove ballerina/regex dependency

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,7 @@ jobs:
           ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
           ./gradlew codeCoverageReport --console=plain --no-daemon
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   windows-build:
     runs-on: windows-latest

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,6 @@ subprojects {
         ballerinaStdLibs "io.ballerina:observe-ballerina:${observeInternalVersion}"
 
         // Standard Library Dependencies
-        ballerinaStdLibs "io.ballerina.stdlib:regex-ballerina:${stdlibRegexVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:http-ballerina:${stdlibHttpVersion}"
 
         // Standard Library Transitive Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,6 @@ observeInternalVersion=1.2.2-20240404-122400-22ed15c
 stdlibConstraintVersion=1.4.0-20230831-142400-50e4023
 stdlibHttpVersion=2.10.13-20240327-141300-ecd1355
 stdlibIoVersion=1.6.0-20230831-135000-049f91a
-stdlibRegexVersion=1.3.2
 stdlibOsVersion=1.8.0-20230831-142200-cb96913
 stdlibTimeVersion=2.4.0-20230831-134800-62143cd
 stdlibUrlVersion=2.4.0-20230831-134600-aab5a12

--- a/prometheus-extension-ballerina/Dependencies.toml
+++ b/prometheus-extension-ballerina/Dependencies.toml
@@ -21,10 +21,5 @@ version = "@stdlib.io.version@"
 
 [[dependency]]
 org = "ballerina"
-name = "regex"
-version = "@stdlib.regex.version@"
-
-[[dependency]]
-org = "ballerina"
 name = "http"
 version = "@stdlib.http.version@"

--- a/prometheus-extension-ballerina/build.gradle
+++ b/prometheus-extension-ballerina/build.gradle
@@ -115,7 +115,6 @@ def stripBallerinaExtensionVersion(String extVersion) {
 task updateTomlVerions {
     doLast {
         def stdlibDependentIoVersion = stripBallerinaExtensionVersion(project.stdlibIoVersion)
-        def stdlibDependentRegexVersion = stripBallerinaExtensionVersion(project.stdlibRegexVersion)
         def stdlibDependentHttpVersion = stripBallerinaExtensionVersion(project.stdlibHttpVersion)
 
         def newConfig = ballerinaConfigFile.text.replace("@project.version@", project.version)
@@ -123,7 +122,6 @@ task updateTomlVerions {
         ballerinaConfigFile.text = newConfig
 
         def newDependencyConfig = ballerinaDependencyFile.text.replace("@stdlib.io.version@", stdlibDependentIoVersion)
-        newDependencyConfig = newDependencyConfig.replace("@stdlib.regex.version@", stdlibDependentRegexVersion)
         newDependencyConfig = newDependencyConfig.replace("@stdlib.http.version@", stdlibDependentHttpVersion)
         ballerinaDependencyFile.text = newDependencyConfig
     }

--- a/prometheus-extension-ballerina/metric_reporter.bal
+++ b/prometheus-extension-ballerina/metric_reporter.bal
@@ -18,7 +18,6 @@ import ballerina/io;
 import ballerina/http;
 import ballerina/lang.'string as str;
 import ballerina/observe;
-import ballerina/regex;
 
 const REPORTER_NAME = "prometheus";
 
@@ -161,7 +160,8 @@ isolated function getTagsString(map<string> labels) returns string {
 # + str - string to be escaped.
 # + return - escaped string.
 isolated function getEscapedName(string str) returns string {
-    return regex:replaceAll(str, "[^a-zA-Z0-9:_]", "_");
+    string:RegExp regExp = re `[^a-zA-Z0-9:_]`;
+    return regExp.replaceAll(str, "_");
 }
 
 # Only [^a-zA-Z0-9\\/.:_* ] are valid in metric lable values, any other characters
@@ -170,7 +170,8 @@ isolated function getEscapedName(string str) returns string {
 # + str - string to be escaped.
 # + return - escaped string.
 isolated function getEscapedLabelValue(string str) returns string {
-    return regex:replaceAll(str, "[^a-zA-Z0-9\\/.:_* ]", "_");
+    string:RegExp regExp = re `[^a-zA-Z0-9\\/.:_* ]`;
+    return regExp.replaceAll(str, "_");
 }
 
 # Add the summary type name to summary type metrics.


### PR DESCRIPTION
## Purpose
In some occasions, the following error occurs intermittently.

```
2024-04-25 09:15:29,335] SEVERE {b7a.log.crash} - 'io.ballerina.runtime.api.values.BString ballerina.regex.1.natives.replaceAll(io.ballerina.runtime.internal.scheduling.Strand, io.ballerina.runtime.api.values.BString, io.ballerina.runtime.api.values.BString, java.lang.Object)' 
java.lang.NoSuchMethodError: 'io.ballerina.runtime.api.values.BString ballerina.regex.1.natives.replaceAll(io.ballerina.runtime.internal.scheduling.Strand, io.ballerina.runtime.api.values.BString, io.ballerina.runtime.api.values.BString, java.lang.Object)'
        at ballerinax.prometheus.0.metric_reporter.getEscapedName(metric_reporter.bal:164)
        at ballerinax.prometheus.0.$value$$anonType$_0.$get$metrics(metric_reporter.bal:68)
        at ballerinax.prometheus.0.$value$$anonType$_0.call(metric_reporter.bal)
        at io.ballerina.runtime.internal.BalRuntime.lambda$getFunction$1(BalRuntime.java:322)
        at io.ballerina.runtime.internal.scheduling.SchedulerItem.execute(SchedulerItem.java:54)
        at io.ballerina.runtime.internal.scheduling.Scheduler.run(Scheduler.java:320)
        at io.ballerina.runtime.internal.scheduling.Scheduler.runSafely(Scheduler.java:287)
        at java.base/java.lang.Thread.run(Thread.java:833)
 
error: java.lang.NoSuchMethodError: 'io.ballerina.runtime.api.values.BString ballerina.regex.1.natives.replaceAll(io.ballerina.runtime.internal.scheduling.Strand, io.ballerina.runtime.api.values.BString, io.ballerina.runtime.api.values.BString, java.lang.Object)'
        at ballerinax.prometheus.0:getEscapedName(metric_reporter.bal:164)
           ballerinax.prometheus.0.$anonType$_0:$get$metrics(metric_reporter.bal:68)
```

ballerina/regex module has been replaced by the lang.regexp module. Therefore, we can replace the ballerina/regex dependency with lang.regexp.
