### PR TITLE
Remove config for Resource method (/metrics)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 group=org.ballerinalang
-version=0.3.0-SNAPSHOT
+version=0.3.1-SNAPSHOT
 ballerinaLangVersion=2201.9.0
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/prometheus-extension-ballerina/metric_reporter.bal
+++ b/prometheus-extension-ballerina/metric_reporter.bal
@@ -56,9 +56,6 @@ isolated function startReporter(string host, int port) returns error? {
         service object {
             # This method retrieves all metrics registered in the ballerina metrics registry,
             # and reformats based on the expected format by prometheus server.
-            @http:ResourceConfig {
-                produces: ["application/text"]
-            }
             resource function get metrics(http:Caller caller) {
                 observe:Metric?[] metrics = observe:getAllMetrics();
                 string[] payload = [];


### PR DESCRIPTION
## Purpose
An error occurred while listening to the metrics endpoint from the datadog agent.
```
check:prometheus | Error running check: [{"message": "406 Client Error: Not Acceptable for url: http://localhost:9797/metrics"
```

A similar issue was occurred earlier and has been reported in [issue](https://github.com/ballerina-platform/ballerina-lang/issues/39862).

This will fix both issues.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39862
